### PR TITLE
GH-34966: Add InsertField and FieldIndex to Schema object

### DIFF
--- a/go/arrow/schema.go
+++ b/go/arrow/schema.go
@@ -197,6 +197,26 @@ func (sc *Schema) FieldIndices(n string) []int {
 	return sc.index[n]
 }
 
+// FieldIndex return index of the unique field with the given name.
+// Returns -1 if the name isn’t found or there are several fields with the given name.
+func (sc *Schema) FieldIndex(name string) int {
+	indices := sc.index[name]
+	if len(indices) != 1 {
+		return -1
+	}
+	return indices[0]
+}
+
+func (sc *Schema) InsertField(i int, f Field) *Schema {
+	if f.Type == nil {
+		panic("arrow: field with nil DataType")
+	}
+	fields := make([]Field, len(sc.fields)+1)
+	copy(fields[:i], sc.fields[:i])
+	copy(fields[i+1:], sc.fields[i:])
+	fields[i] = f
+	return NewSchemaWithEndian(fields, &sc.meta, sc.endianness)
+}
 func (sc *Schema) HasField(n string) bool { return len(sc.FieldIndices(n)) > 0 }
 func (sc *Schema) HasMetadata() bool      { return len(sc.meta.keys) > 0 }
 

--- a/go/arrow/schema.go
+++ b/go/arrow/schema.go
@@ -207,16 +207,6 @@ func (sc *Schema) FieldIndex(name string) int {
 	return indices[0]
 }
 
-func (sc *Schema) InsertField(i int, f Field) *Schema {
-	if f.Type == nil {
-		panic("arrow: field with nil DataType")
-	}
-	fields := make([]Field, len(sc.fields)+1)
-	copy(fields[:i], sc.fields[:i])
-	copy(fields[i+1:], sc.fields[i:])
-	fields[i] = f
-	return NewSchemaWithEndian(fields, &sc.meta, sc.endianness)
-}
 func (sc *Schema) HasField(n string) bool { return len(sc.FieldIndices(n)) > 0 }
 func (sc *Schema) HasMetadata() bool      { return len(sc.meta.keys) > 0 }
 

--- a/go/arrow/schema_test.go
+++ b/go/arrow/schema_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 
 	"github.com/apache/arrow/go/v12/arrow/endian"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestMetadata(t *testing.T) {
@@ -422,26 +421,4 @@ func TestSchemaEqual(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestSchemaInsertField(t *testing.T) {
-	fields := []Field{
-		{Name: "f1", Type: PrimitiveTypes.Int32},
-		{Name: "f2", Type: PrimitiveTypes.Int64},
-	}
-	md := func() *Metadata {
-		md := MetadataFrom(map[string]string{"k1": "v1", "k2": "v2"})
-		return &md
-	}()
-	sc := NewSchema(fields, md)
-	sc1 := sc.InsertField(0, Field{Name: "f0", Type: PrimitiveTypes.Int32})
-	assert.False(t, sc.Equal(sc1))
-
-	fields1 := []Field{
-		{Name: "f0", Type: PrimitiveTypes.Int32},
-		{Name: "f1", Type: PrimitiveTypes.Int32},
-		{Name: "f2", Type: PrimitiveTypes.Int64},
-	}
-	sc2 := NewSchema(fields1, md)
-	assert.True(t, sc1.Equal(sc2))
 }


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->