### PR TITLE
GH-35160: [Go] Add arrayApproxEqualString to ignore null chars

### DIFF
--- a/go/arrow/array/binarybuilder.go
+++ b/go/arrow/array/binarybuilder.go
@@ -19,6 +19,7 @@ package array
 import (
 	"bytes"
 	"encoding/base64"
+	"encoding/hex"
 	"fmt"
 	"math"
 	"reflect"
@@ -319,7 +320,10 @@ func (b *BinaryBuilder) UnmarshalOne(dec *json.Decoder) error {
 	case string:
 		data, err := base64.StdEncoding.DecodeString(v)
 		if err != nil {
-			return err
+			data, err = hex.DecodeString(v)
+			if err != nil {
+				return err
+			}
 		}
 		b.Append(data)
 	case []byte:

--- a/go/arrow/array/compare.go
+++ b/go/arrow/array/compare.go
@@ -19,6 +19,7 @@ package array
 import (
 	"fmt"
 	"math"
+	"strings"
 
 	"github.com/apache/arrow/go/v12/arrow"
 	"github.com/apache/arrow/go/v12/arrow/float16"
@@ -494,13 +495,13 @@ func arrayApproxEqual(left, right arrow.Array, opt equalOption) bool {
 		return arrayEqualBinary(l, r)
 	case *String:
 		r := right.(*String)
-		return arrayEqualString(l, r)
+		return arrayApproxEqualString(l, r)
 	case *LargeBinary:
 		r := right.(*LargeBinary)
 		return arrayEqualLargeBinary(l, r)
 	case *LargeString:
 		r := right.(*LargeString)
-		return arrayEqualLargeString(l, r)
+		return arrayApproxEqualLargeString(l, r)
 	case *Int8:
 		r := right.(*Int8)
 		return arrayEqualInt8(l, r)
@@ -624,6 +625,34 @@ func validityBitmapEqual(left, right arrow.Array) bool {
 	}
 	for i := 0; i < n; i++ {
 		if left.IsNull(i) != right.IsNull(i) {
+			return false
+		}
+	}
+	return true
+}
+
+func stripNulls(s string) string {
+	return strings.ReplaceAll(s, "\x00", "")
+}
+
+func arrayApproxEqualString(left, right *String) bool {
+	for i := 0; i < left.Len(); i++ {
+		if left.IsNull(i) {
+			continue
+		}
+		if stripNulls(left.Value(i)) != stripNulls(right.Value(i)) {
+			return false
+		}
+	}
+	return true
+}
+
+func arrayApproxEqualLargeString(left, right *LargeString) bool {
+	for i := 0; i < left.Len(); i++ {
+		if left.IsNull(i) {
+			continue
+		}
+		if stripNulls(left.Value(i)) != stripNulls(right.Value(i)) {
 			return false
 		}
 	}


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->