### PR TITLE
fix: Only cast int8 and unit8 when JSON marshaling arrays

### DIFF
--- a/go/arrow/array/numeric.gen.go
+++ b/go/arrow/array/numeric.gen.go
@@ -101,9 +101,7 @@ func (a *Int64) MarshalJSON() ([]byte, error) {
 	vals := make([]interface{}, a.Len())
 	for i := 0; i < a.Len(); i++ {
 		if a.IsValid(i) {
-
 			vals[i] = a.values[i]
-
 		} else {
 			vals[i] = nil
 		}
@@ -198,9 +196,7 @@ func (a *Uint64) MarshalJSON() ([]byte, error) {
 	vals := make([]interface{}, a.Len())
 	for i := 0; i < a.Len(); i++ {
 		if a.IsValid(i) {
-
 			vals[i] = a.values[i]
-
 		} else {
 			vals[i] = nil
 		}
@@ -295,9 +291,7 @@ func (a *Float64) MarshalJSON() ([]byte, error) {
 	vals := make([]interface{}, a.Len())
 	for i := 0; i < a.Len(); i++ {
 		if a.IsValid(i) {
-
 			vals[i] = a.values[i]
-
 		} else {
 			vals[i] = nil
 		}
@@ -392,9 +386,7 @@ func (a *Int32) MarshalJSON() ([]byte, error) {
 	vals := make([]interface{}, a.Len())
 	for i := 0; i < a.Len(); i++ {
 		if a.IsValid(i) {
-
 			vals[i] = a.values[i]
-
 		} else {
 			vals[i] = nil
 		}
@@ -489,9 +481,7 @@ func (a *Uint32) MarshalJSON() ([]byte, error) {
 	vals := make([]interface{}, a.Len())
 	for i := 0; i < a.Len(); i++ {
 		if a.IsValid(i) {
-
 			vals[i] = a.values[i]
-
 		} else {
 			vals[i] = nil
 		}
@@ -586,9 +576,7 @@ func (a *Float32) MarshalJSON() ([]byte, error) {
 	vals := make([]interface{}, a.Len())
 	for i := 0; i < a.Len(); i++ {
 		if a.IsValid(i) {
-
 			vals[i] = a.values[i]
-
 		} else {
 			vals[i] = nil
 		}
@@ -683,9 +671,7 @@ func (a *Int16) MarshalJSON() ([]byte, error) {
 	vals := make([]interface{}, a.Len())
 	for i := 0; i < a.Len(); i++ {
 		if a.IsValid(i) {
-
 			vals[i] = a.values[i]
-
 		} else {
 			vals[i] = nil
 		}
@@ -780,9 +766,7 @@ func (a *Uint16) MarshalJSON() ([]byte, error) {
 	vals := make([]interface{}, a.Len())
 	for i := 0; i < a.Len(); i++ {
 		if a.IsValid(i) {
-
 			vals[i] = a.values[i]
-
 		} else {
 			vals[i] = nil
 		}
@@ -877,7 +861,6 @@ func (a *Int8) MarshalJSON() ([]byte, error) {
 	vals := make([]interface{}, a.Len())
 	for i := 0; i < a.Len(); i++ {
 		if a.IsValid(i) {
-
 			vals[i] = float64(a.values[i]) // prevent uint8 from being seen as binary data
 
 		} else {
@@ -974,7 +957,6 @@ func (a *Uint8) MarshalJSON() ([]byte, error) {
 	vals := make([]interface{}, a.Len())
 	for i := 0; i < a.Len(); i++ {
 		if a.IsValid(i) {
-
 			vals[i] = float64(a.values[i]) // prevent uint8 from being seen as binary data
 
 		} else {

--- a/go/arrow/array/numeric.gen.go
+++ b/go/arrow/array/numeric.gen.go
@@ -862,7 +862,6 @@ func (a *Int8) MarshalJSON() ([]byte, error) {
 	for i := 0; i < a.Len(); i++ {
 		if a.IsValid(i) {
 			vals[i] = float64(a.values[i]) // prevent uint8 from being seen as binary data
-
 		} else {
 			vals[i] = nil
 		}
@@ -958,7 +957,6 @@ func (a *Uint8) MarshalJSON() ([]byte, error) {
 	for i := 0; i < a.Len(); i++ {
 		if a.IsValid(i) {
 			vals[i] = float64(a.values[i]) // prevent uint8 from being seen as binary data
-
 		} else {
 			vals[i] = nil
 		}

--- a/go/arrow/array/numeric.gen.go
+++ b/go/arrow/array/numeric.gen.go
@@ -101,7 +101,9 @@ func (a *Int64) MarshalJSON() ([]byte, error) {
 	vals := make([]interface{}, a.Len())
 	for i := 0; i < a.Len(); i++ {
 		if a.IsValid(i) {
-			vals[i] = float64(a.values[i]) // prevent uint8 from being seen as binary data
+
+			vals[i] = a.values[i]
+
 		} else {
 			vals[i] = nil
 		}
@@ -196,7 +198,9 @@ func (a *Uint64) MarshalJSON() ([]byte, error) {
 	vals := make([]interface{}, a.Len())
 	for i := 0; i < a.Len(); i++ {
 		if a.IsValid(i) {
-			vals[i] = float64(a.values[i]) // prevent uint8 from being seen as binary data
+
+			vals[i] = a.values[i]
+
 		} else {
 			vals[i] = nil
 		}
@@ -291,7 +295,9 @@ func (a *Float64) MarshalJSON() ([]byte, error) {
 	vals := make([]interface{}, a.Len())
 	for i := 0; i < a.Len(); i++ {
 		if a.IsValid(i) {
-			vals[i] = float64(a.values[i]) // prevent uint8 from being seen as binary data
+
+			vals[i] = a.values[i]
+
 		} else {
 			vals[i] = nil
 		}
@@ -386,7 +392,9 @@ func (a *Int32) MarshalJSON() ([]byte, error) {
 	vals := make([]interface{}, a.Len())
 	for i := 0; i < a.Len(); i++ {
 		if a.IsValid(i) {
-			vals[i] = float64(a.values[i]) // prevent uint8 from being seen as binary data
+
+			vals[i] = a.values[i]
+
 		} else {
 			vals[i] = nil
 		}
@@ -481,7 +489,9 @@ func (a *Uint32) MarshalJSON() ([]byte, error) {
 	vals := make([]interface{}, a.Len())
 	for i := 0; i < a.Len(); i++ {
 		if a.IsValid(i) {
-			vals[i] = float64(a.values[i]) // prevent uint8 from being seen as binary data
+
+			vals[i] = a.values[i]
+
 		} else {
 			vals[i] = nil
 		}
@@ -576,7 +586,9 @@ func (a *Float32) MarshalJSON() ([]byte, error) {
 	vals := make([]interface{}, a.Len())
 	for i := 0; i < a.Len(); i++ {
 		if a.IsValid(i) {
-			vals[i] = float64(a.values[i]) // prevent uint8 from being seen as binary data
+
+			vals[i] = a.values[i]
+
 		} else {
 			vals[i] = nil
 		}
@@ -671,7 +683,9 @@ func (a *Int16) MarshalJSON() ([]byte, error) {
 	vals := make([]interface{}, a.Len())
 	for i := 0; i < a.Len(); i++ {
 		if a.IsValid(i) {
-			vals[i] = float64(a.values[i]) // prevent uint8 from being seen as binary data
+
+			vals[i] = a.values[i]
+
 		} else {
 			vals[i] = nil
 		}
@@ -766,7 +780,9 @@ func (a *Uint16) MarshalJSON() ([]byte, error) {
 	vals := make([]interface{}, a.Len())
 	for i := 0; i < a.Len(); i++ {
 		if a.IsValid(i) {
-			vals[i] = float64(a.values[i]) // prevent uint8 from being seen as binary data
+
+			vals[i] = a.values[i]
+
 		} else {
 			vals[i] = nil
 		}
@@ -861,7 +877,9 @@ func (a *Int8) MarshalJSON() ([]byte, error) {
 	vals := make([]interface{}, a.Len())
 	for i := 0; i < a.Len(); i++ {
 		if a.IsValid(i) {
+
 			vals[i] = float64(a.values[i]) // prevent uint8 from being seen as binary data
+
 		} else {
 			vals[i] = nil
 		}
@@ -956,7 +974,9 @@ func (a *Uint8) MarshalJSON() ([]byte, error) {
 	vals := make([]interface{}, a.Len())
 	for i := 0; i < a.Len(); i++ {
 		if a.IsValid(i) {
+
 			vals[i] = float64(a.values[i]) // prevent uint8 from being seen as binary data
+
 		} else {
 			vals[i] = nil
 		}

--- a/go/arrow/array/numeric.gen.go.tmpl
+++ b/go/arrow/array/numeric.gen.go.tmpl
@@ -134,7 +134,11 @@ func (a *{{.Name}}) MarshalJSON() ([]byte, error) {
 	vals := make([]interface{}, a.Len())
 	for i := 0; i < a.Len(); i++ {
 		if a.IsValid(i) {
+			{{ if (eq .Size "1") }}
 			vals[i] = float64(a.values[i]) // prevent uint8 from being seen as binary data
+			{{ else }}
+			vals[i] = a.values[i]
+			{{ end }}
 		} else {
 			vals[i] = nil
 		}

--- a/go/arrow/array/numeric.gen.go.tmpl
+++ b/go/arrow/array/numeric.gen.go.tmpl
@@ -134,11 +134,8 @@ func (a *{{.Name}}) MarshalJSON() ([]byte, error) {
 	vals := make([]interface{}, a.Len())
 	for i := 0; i < a.Len(); i++ {
 		if a.IsValid(i) {
-			{{ if (eq .Size "1") }}
-			vals[i] = float64(a.values[i]) // prevent uint8 from being seen as binary data
-			{{ else }}
-			vals[i] = a.values[i]
-			{{ end }}
+			{{ if (eq .Size "1") }}vals[i] = float64(a.values[i]) // prevent uint8 from being seen as binary data
+			{{ else }}vals[i] = a.values[i]{{ end }}
 		} else {
 			vals[i] = nil
 		}

--- a/go/arrow/array/numeric.gen.go.tmpl
+++ b/go/arrow/array/numeric.gen.go.tmpl
@@ -134,8 +134,7 @@ func (a *{{.Name}}) MarshalJSON() ([]byte, error) {
 	vals := make([]interface{}, a.Len())
 	for i := 0; i < a.Len(); i++ {
 		if a.IsValid(i) {
-			{{ if (eq .Size "1") }}vals[i] = float64(a.values[i]) // prevent uint8 from being seen as binary data
-			{{ else }}vals[i] = a.values[i]{{ end }}
+			{{ if (eq .Size "1") }}vals[i] = float64(a.values[i]) // prevent uint8 from being seen as binary data{{ else }}vals[i] = a.values[i]{{ end }}
 		} else {
 			vals[i] = nil
 		}

--- a/go/arrow/array/numeric_test.go
+++ b/go/arrow/array/numeric_test.go
@@ -632,3 +632,61 @@ func TestDate64SliceDataWithNull(t *testing.T) {
 		t.Fatalf("got=%v, want=%v", got, want)
 	}
 }
+
+func TestInt64MarshalJSON(t *testing.T) {
+	pool := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer pool.AssertSize(t, 0)
+
+	var (
+		vs = []int64{-5474557666971701248}
+	)
+
+	b := array.NewInt64Builder(pool)
+	defer b.Release()
+
+	for _, v := range vs {
+		b.Append(v)
+	}
+
+	arr := b.NewArray().(*array.Int64)
+	defer arr.Release()
+
+	jsonBytes, err := json.Marshal(arr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(jsonBytes)
+	want := `[-5474557666971701248]`
+	if got != want {
+		t.Fatalf("got=%s, want=%s", got, want)
+	}
+}
+
+func TestUInt64MarshalJSON(t *testing.T) {
+	pool := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer pool.AssertSize(t, 0)
+
+	var (
+		vs = []uint64{14697929703826477056}
+	)
+
+	b := array.NewUint64Builder(pool)
+	defer b.Release()
+
+	for _, v := range vs {
+		b.Append(v)
+	}
+
+	arr := b.NewArray().(*array.Uint64)
+	defer arr.Release()
+
+	jsonBytes, err := json.Marshal(arr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(jsonBytes)
+	want := `[14697929703826477056]`
+	if got != want {
+		t.Fatalf("got=%s, want=%s", got, want)
+	}
+}


### PR DESCRIPTION
Same as https://github.com/apache/arrow/pull/35950/commits just for `cqmain`